### PR TITLE
GP-44577 Improve BPK lookup selection logic

### DIFF
--- a/CRM/Bpk/DataLogic.php
+++ b/CRM/Bpk/DataLogic.php
@@ -88,6 +88,7 @@ class CRM_Bpk_DataLogic {
           $reset['bpk.vbpk']           = '';
           $reset['bpk.bpk_error_code'] = '';
           $reset['bpk.bpk_error_note'] = '';
+          $reset['bpk.bpk_lookup_date'] = NULL;
           CRM_Bpk_CustomData::resolveCustomFields($reset);
           self::$scheduled_reset = $reset;
         }
@@ -124,11 +125,13 @@ class CRM_Bpk_DataLogic {
           self::addCustomUpdate('vbpk',       '', $params, $update);
           self::addCustomUpdate('error_code', '', $params, $update);
           self::addCustomUpdate('error_note', '', $params, $update);
+          self::addCustomUpdate('lookup_date', '', $params, $update);
           break;
 
         case BPK_STATUS_MANUAL:
           self::addCustomUpdate('error_code', '', $params, $update);
           self::addCustomUpdate('error_note', '', $params, $update);
+          self::addCustomUpdate('lookup_date', '', $params, $update);
           break;
 
         case BPK_STATUS_RESOLVED:

--- a/CRM/Bpk/Upgrader.php
+++ b/CRM/Bpk/Upgrader.php
@@ -93,4 +93,16 @@ class CRM_Bpk_Upgrader extends CRM_Bpk_Upgrader_Base {
 
     return TRUE;
   }
+
+  /**
+   * add lookup_date
+   *
+   * @return true
+   * @throws \Exception
+   */
+  public function upgrade_0110() {
+    $customData = new CRM_Bpk_CustomData('de.systopia.bpk');
+    $customData->syncCustomGroup(__DIR__ . '/../../resources/bpk_custom_group.json');
+    return TRUE;
+  }
 }

--- a/resources/bpk_custom_group.json
+++ b/resources/bpk_custom_group.json
@@ -97,6 +97,23 @@
       "is_view": "0",
       "column_name": "error_note",
       "in_selector": "1"
+    },
+    {
+      "_lookup": ["column_name", "custom_group_id"],
+      "_translate": ["label"],
+      "weight": "6",
+      "name": "bpk_lookup_date",
+      "column_name": "lookup_date",
+      "label": "Lookup Date",
+      "data_type": "Date",
+      "html_type": "Select Date",
+      "time_format": "2",
+      "is_required": "0",
+      "is_searchable": "1",
+      "is_search_range": "1",
+      "is_active": "1",
+      "is_view": "0",
+      "in_selector": "1"
     }
   ]
 }

--- a/settings/bpk.setting.php
+++ b/settings/bpk.setting.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+  'bpk_lookup_retry_interval' => [
+    'name'       => 'bpk_lookup_retry_interval',
+    'type'       => 'Integer',
+    'html_type'  => 'text',
+    'default'    => 90,
+    'add'        => '1.1',
+    'title'      => ts('BPK Lookup Retry Interval'),
+    'is_domain'  => 1,
+    'is_contact' => 0,
+  ],
+];


### PR DESCRIPTION
This improves the BPK lookup logic by adding a "self-healing" mechanism for certain scenarios. Lookups are now performed as follows:

1. BPKs that have not yet been resolved (Status=Unknown)
2. BPK records in an invalid state (status does not make sense in combination with BPK value)
3. BPK Status=Error and retryable error code
4. BPK Status=No Match/Error/Ambiguous and lookup_date is older than bpk_lookup_retry_interval

A new column lookup_date and setting bpk_lookup_retry_interval was added for this purpose.